### PR TITLE
remove raspicam driver from the depends

### DIFF
--- a/ansible/roles/core/tasks/main.yml
+++ b/ansible/roles/core/tasks/main.yml
@@ -137,15 +137,3 @@
     dest: "{{workspace_path}}/src/drivers/nmea_gps_driver"
     version: master
     accept_hostkey: yes
-
-- name: clone raspicam
-  git:
-    repo: https://github.com/OUXT-Polaris/raspicam.git
-    dest: "{{workspace_path}}/src/drivers/raspicam"
-    version: master
-- name: clone raspicam driver
-  git:
-    repo: https://github.com/OUXT-Polaris/raspicam_driver.git
-    dest: "{{workspace_path}}/src/drivers/raspicam_driver"
-    version: master
-    accept_hostkey: yes


### PR DESCRIPTION
Signed-off-by: Masaya Kataoka <ms.kataoka@gmail.com>

remove raspicam/raspicam driver package from depends