### PR TITLE
add playstation_cotnroller_drivers package to the depends

### DIFF
--- a/ansible/roles/core/tasks/main.yml
+++ b/ansible/roles/core/tasks/main.yml
@@ -167,6 +167,12 @@
     dest: "{{workspace_path}}/src/drivers/librealsense_vendor"
     version: master
     accept_hostkey: yes
+- name: clone playstation_controller_drivers
+  git:
+    repo: https://github.com/OUXT-Polaris/playstation_controller_drivers
+    dest: "{{workspace_path}}/src/drivers/playstation_controller_drivers"
+    version: master
+    accept_hostkey: yes
 
 # Control Package
 - name: clone usv_controller package


### PR DESCRIPTION
Signed-off-by: Masaya Kataoka <ms.kataoka@gmail.com>

add playstation_cotnroller_drivers package