### PR TITLE
add realsense hardware interface package to the depends

### DIFF
--- a/ansible/roles/core/tasks/main.yml
+++ b/ansible/roles/core/tasks/main.yml
@@ -167,6 +167,13 @@
     dest: "{{workspace_path}}/src/drivers/playstation_controller_drivers"
     version: master
     accept_hostkey: yes
+- name: clone realsense_hardware_interface
+  git:
+    repo: https://github.com/OUXT-Polaris/realsense_hardware_interface.git
+    dest: "{{workspace_path}}/src/drivers/realsense_hardware_interface"
+    version: master
+    accept_hostkey: yes
+
 
 # Control Package
 - name: clone usv_controller package


### PR DESCRIPTION
Signed-off-by: Masaya Kataoka <ms.kataoka@gmail.com>

adding realsense_hardware_interface package to the depends